### PR TITLE
Support SSL

### DIFF
--- a/Commands/Migrate.php
+++ b/Commands/Migrate.php
@@ -30,9 +30,9 @@ class Migrate extends ConsoleCommand
         $this->addRequiredValueOption('target-db-name', null, 'Target database name');
         $this->addOptionalValueOption('target-db-prefix', null, 'Target database table prefix', '');
         $this->addRequiredValueOption('target-db-port', null, 'Target database port', '3306');
-        $this->addOptionalValueOption('target-db-enable-ssl', null, 'Used for establishing secure connections using SSL with target database host.', 0);
         $this->addOptionalValueOption('target-db-ssl-ca', null, 'The path name to the certificate authority file.', '/etc/ssl/certs/cert.pem');
-        $this->addOptionalValueOption('target-db-ssl-no-verify', null, 'Disable server certificate validation of the target database.', 0);
+        $this->addNoValueOption('target-db-enable-ssl', null, 'Used for establishing secure connections using SSL with target database host.');
+        $this->addNoValueOption('target-db-ssl-no-verify', null, 'Disable server certificate validation of the target database host.');
         $this->addNoValueOption('skip-logs', null, 'Skip migration of logs');
         $this->addNoValueOption('skip-archives', null, 'Skip migration of archives');
         $this->addNoValueOption('dry-run', null, 'Enable debug mode where it does not insert anything.');

--- a/Commands/Migrate.php
+++ b/Commands/Migrate.php
@@ -30,6 +30,9 @@ class Migrate extends ConsoleCommand
         $this->addRequiredValueOption('target-db-name', null, 'Target database name');
         $this->addOptionalValueOption('target-db-prefix', null, 'Target database table prefix', '');
         $this->addRequiredValueOption('target-db-port', null, 'Target database port', '3306');
+        $this->addOptionalValueOption('target-db-enable-ssl', null, 'Used for establishing secure connections using SSL with target database host.', 0);
+        $this->addOptionalValueOption('target-db-ssl-ca', null, 'The path name to the certificate authority file.', '/etc/ssl/certs/cert.pem');
+        $this->addOptionalValueOption('target-db-ssl-no-verify', null, 'Disable server certificate validation of the target database.', 0);
         $this->addNoValueOption('skip-logs', null, 'Skip migration of logs');
         $this->addNoValueOption('skip-archives', null, 'Skip migration of archives');
         $this->addNoValueOption('dry-run', null, 'Enable debug mode where it does not insert anything.');
@@ -121,6 +124,9 @@ class Migrate extends ConsoleCommand
             'dbname' => $input->getOption('target-db-name'),
             'tables_prefix' => $input->getOption('target-db-prefix'),
             'port' => $input->getOption('target-db-port'),
+            'enable_ssl' => $input->getOption('target-db-enable-ssl'),
+            'ssl_ca' => $input->getOption('target-db-ssl-ca'),
+            'ssl_no_verify' => $input->getOption('target-db-ssl-no-verify'),
         ));
     }
 

--- a/README.md
+++ b/README.md
@@ -32,12 +32,15 @@ To start a migration execute the `migration:measurable` command, example:
 Optional parameters are:
 
 ```
- --target-db-prefix=piwik_      Target database table prefix (default: "")
- --target-db-port=3306          Target database port (default: "3306")
- --skip-logs                    Skip migration of logs (Raw tracking data)
- --skip-archives                Skip migration of archives (Report data)
- --dry-run                      Enable debug mode where it does not insert anything.
- --disable-db-transactions      Disable the usage of MySQL database transactions
+ --target-db-prefix=piwik_                          Target database table prefix (default: "")
+ --target-db-port=3306                              Target database port (default: "3306")
+ --target-db-enable-ssl=1                           Used for establishing secure connections using SSL with target database host (default: 0)
+ --target-db-ssl-ca=/etc/ssl/certs/cert.pem         The path name to the certificate authority file (default: "/etc/ssl/certs/cert.pem")
+ --target-db-ssl-no-verify=1                        Disable server certificate validation of the target database (default: 0)
+ --skip-logs                                        Skip migration of logs (Raw tracking data)
+ --skip-archives                                    Skip migration of archives (Report data)
+ --dry-run                                          Enable debug mode where it does not insert anything.
+ --disable-db-transactions                          Disable the usage of MySQL database transactions
 ```
 
 Both Matomo instances may be on different servers with proper firewall rules that restrict database access on target instance.

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Optional parameters are:
 ```
  --target-db-prefix=piwik_                          Target database table prefix (default: "")
  --target-db-port=3306                              Target database port (default: "3306")
- --target-db-enable-ssl=1                           Used for establishing secure connections using SSL with target database host (default: 0)
+ --target-db-enable-ssl                             Used for establishing secure connections using SSL with target database host
  --target-db-ssl-ca=/etc/ssl/certs/cert.pem         The path name to the certificate authority file (default: "/etc/ssl/certs/cert.pem")
- --target-db-ssl-no-verify=1                        Disable server certificate validation of the target database (default: 0)
+ --target-db-ssl-no-verify                          Disable server certificate validation of the target database
  --skip-logs                                        Skip migration of logs (Raw tracking data)
  --skip-archives                                    Skip migration of archives (Report data)
  --dry-run                                          Enable debug mode where it does not insert anything.


### PR DESCRIPTION
### Description:

Added the following optional parameters to support SSL:
--target-db-enable-ssl=
--target-db-ssl-ca=
--target-db-ssl-no-verify=

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
