### PR TITLE
Allow annotations migration to work with both option and annotations tables

### DIFF
--- a/Migrations/AnnotationsMigration.php
+++ b/Migrations/AnnotationsMigration.php
@@ -9,6 +9,7 @@
 
 namespace Piwik\Plugins\Migration\Migrations;
 
+use Piwik\Common;
 use Piwik\Option;
 use Piwik\Plugins\Annotations\AnnotationList;
 use Piwik\Plugins\Migration\TargetDb;
@@ -30,6 +31,11 @@ class AnnotationsMigration extends BaseMigration
         return [];
     }
 
+    /**
+     * @param Request $request
+     * @param TargetDb $targetDb
+     * @return void
+     */
     public function migrate(Request $request, TargetDb $targetDb)
     {
         // since Matomo 5.5.0, annotations are stored in their own table
@@ -46,7 +52,8 @@ class AnnotationsMigration extends BaseMigration
 
         $annotations = Option::get($sourceName);
         if ($annotations) {
-            $this->log('Found annotations');
+            $annotationItems = Common::safe_unserialize($annotations) ?: [];
+            $this->log(sprintf('Found %d annotations', count($annotationItems)));
 
             $targetDb->insert('option', array(
                 'option_name' => $targetName,

--- a/Migrations/AnnotationsMigration.php
+++ b/Migrations/AnnotationsMigration.php
@@ -15,13 +15,32 @@ use Piwik\Plugins\Migration\TargetDb;
 
 class AnnotationsMigration extends BaseMigration
 {
+    /**
+     * @param TargetDb $targetDb
+     * @return array
+     */
     public function validateStructure(TargetDb $targetDb)
     {
-        return array();
+        // since Matomo 5.5.0, annotations are stored in their own table
+        // and the AnnotationList class had been removed
+        if (!class_exists(AnnotationList::class)) {
+            return $this->checkTablesHaveSameStructure($targetDb, 'annotations');
+        }
+
+        return [];
     }
 
     public function migrate(Request $request, TargetDb $targetDb)
     {
+        // since Matomo 5.5.0, annotations are stored in their own table
+        // and the AnnotationList class had been removed
+        if (!class_exists(AnnotationList::class)) {
+            $this->migrateEntities($request, $targetDb, 'annotations', 'annotations', 'id');
+
+            return;
+        }
+
+        // before Matomo 5.5.0, annotations were stored in the options table
         $sourceName = AnnotationList::getAnnotationCollectionOptionName($request->sourceIdSite);
         $targetName = AnnotationList::getAnnotationCollectionOptionName($request->targetIdSite);
 

--- a/tests/System/Commands/MigrateTest.php
+++ b/tests/System/Commands/MigrateTest.php
@@ -138,6 +138,14 @@ Processed ArchiveMigration at 2019-01-10 02:48:01
         $archives = $targetDb->fetchAll('SELECT * FROM ' . self::$fixture->targetDb->prefixTable('archive_blob_2013_01'));
         $this->assertGreaterThanOrEqual(195, count($archives));
         $this->assertLessThanOrEqual(600, count($archives));
+
+        if (!class_exists('Piwik\Plugins\Annotations\AnnotationList')) {
+            $annotationsTable = self::$fixture->targetDb->prefixTable('annotations');
+            $this->assertContains($annotationsTable, $targetDb->listTables(), 'annotations table does not exist');
+
+            $annotationItems = $targetDb->fetchAll('SELECT * FROM ' . $annotationsTable);
+            $this->assertCount(1, $annotationItems);
+        }
     }
 
     /**

--- a/tests/System/Commands/MigrateTest.php
+++ b/tests/System/Commands/MigrateTest.php
@@ -56,7 +56,7 @@ Processing SegmentsMigration at 2019-01-10 02:48:01
 Found 2 segments at 2019-01-10 02:48:01
 Processed SegmentsMigration at 2019-01-10 02:48:01
 Processing AnnotationsMigration at 2019-01-10 02:48:01
-Found annotations at 2019-01-10 02:48:01
+Found 1 annotations at 2019-01-10 02:48:01
 Processed AnnotationsMigration at 2019-01-10 02:48:01
 Processing CustomDimensionMigration at 2019-01-10 02:48:01
 Found 3 custom dimensions at 2019-01-10 02:48:01


### PR DESCRIPTION
## Description

As a security enhancement in core, annotations are being moved from the option table to their own annotations table. The class AnnotationList is also being removed as not needed, so that can be used as the deciding factor which way of migration to use.

Keeping the use statement for the removed AnnotationList class is ok in PHP.

## Issue No

Relates to https://github.com/matomo-org/matomo/pull/23564 and DEV-13979.

## Checklist
- [✔] Tested locally
- [✔] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitised properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped?