### PR TITLE
Adds code to ignore migration if no option is provided explicitly, #PG-5167

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### 5.0.6 - 2026-05-25
+- Added code to ignore migration if no option is provided explicitly
+
 ### 5.0.6 - 2025-09-29
 - Allow annotations migration to work with both option and annotations tables
 

--- a/Commands/Migrate.php
+++ b/Commands/Migrate.php
@@ -24,14 +24,14 @@ class Migrate extends ConsoleCommand
         $this->setName('migration:measurable');
         $this->setDescription('Migrates a measurable/website from one Matomo instance to another Matomo');
 
-//        $this->addRequiredValueOption('source-idsite', null, 'Source Site ID you want to migrate');
-//        $this->addRequiredValueOption('target-db-host', null, 'Target database host');
-//        $this->addRequiredValueOption('target-db-username', null, 'Target database username');
-//        $this->addOptionalValueOption('target-db-password', null, 'Target database password');
-//        $this->addRequiredValueOption('target-db-name', null, 'Target database name');
-//        $this->addOptionalValueOption('target-db-prefix', null, 'Target database table prefix', '');
-//        $this->addRequiredValueOption('target-db-port', null, 'Target database port', '3306');
-//        $this->addOptionalValueOption('target-db-ssl-ca', null, 'The path name to the certificate authority file.', '/etc/ssl/certs/cert.pem');
+        $this->addRequiredValueOption('source-idsite', null, 'Source Site ID you want to migrate');
+        $this->addRequiredValueOption('target-db-host', null, 'Target database host');
+        $this->addRequiredValueOption('target-db-username', null, 'Target database username');
+        $this->addOptionalValueOption('target-db-password', null, 'Target database password');
+        $this->addRequiredValueOption('target-db-name', null, 'Target database name');
+        $this->addOptionalValueOption('target-db-prefix', null, 'Target database table prefix', '');
+        $this->addRequiredValueOption('target-db-port', null, 'Target database port', '3306');
+        $this->addOptionalValueOption('target-db-ssl-ca', null, 'The path name to the certificate authority file.', '/etc/ssl/certs/cert.pem');
         $this->addNoValueOption('target-db-enable-ssl', null, 'Used for establishing secure connections using SSL with target database host.');
         $this->addNoValueOption('target-db-ssl-no-verify', null, 'Disable server certificate validation of the target database host.');
         $this->addNoValueOption('skip-logs', null, 'Skip migration of logs');

--- a/Commands/Migrate.php
+++ b/Commands/Migrate.php
@@ -24,14 +24,14 @@ class Migrate extends ConsoleCommand
         $this->setName('migration:measurable');
         $this->setDescription('Migrates a measurable/website from one Matomo instance to another Matomo');
 
-        $this->addRequiredValueOption('source-idsite', null, 'Source Site ID you want to migrate');
-        $this->addRequiredValueOption('target-db-host', null, 'Target database host');
-        $this->addRequiredValueOption('target-db-username', null, 'Target database username');
-        $this->addOptionalValueOption('target-db-password', null, 'Target database password');
-        $this->addRequiredValueOption('target-db-name', null, 'Target database name');
-        $this->addOptionalValueOption('target-db-prefix', null, 'Target database table prefix', '');
-        $this->addRequiredValueOption('target-db-port', null, 'Target database port', '3306');
-        $this->addOptionalValueOption('target-db-ssl-ca', null, 'The path name to the certificate authority file.', '/etc/ssl/certs/cert.pem');
+//        $this->addRequiredValueOption('source-idsite', null, 'Source Site ID you want to migrate');
+//        $this->addRequiredValueOption('target-db-host', null, 'Target database host');
+//        $this->addRequiredValueOption('target-db-username', null, 'Target database username');
+//        $this->addOptionalValueOption('target-db-password', null, 'Target database password');
+//        $this->addRequiredValueOption('target-db-name', null, 'Target database name');
+//        $this->addOptionalValueOption('target-db-prefix', null, 'Target database table prefix', '');
+//        $this->addRequiredValueOption('target-db-port', null, 'Target database port', '3306');
+//        $this->addOptionalValueOption('target-db-ssl-ca', null, 'The path name to the certificate authority file.', '/etc/ssl/certs/cert.pem');
         $this->addNoValueOption('target-db-enable-ssl', null, 'Used for establishing secure connections using SSL with target database host.');
         $this->addNoValueOption('target-db-ssl-no-verify', null, 'Disable server certificate validation of the target database host.');
         $this->addNoValueOption('skip-logs', null, 'Skip migration of logs');
@@ -133,6 +133,6 @@ class Migrate extends ConsoleCommand
 
     private function confirmMigration($idSite): bool
     {
-        return $this->askForConfirmation('<question>Are you sure you want to migrate the data for idSite ' . (int) $idSite . '. (y/N)</question>');
+        return $this->askForConfirmation('<question>Are you sure you want to migrate the data for idSite ' . (int) $idSite . '. (y/N)</question>', false);
     }
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "Migration",
   "description": "Migrate/copy any measurable (site, app, roll-up) from one Matomo to another Matomo",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "theme": false,
   "require": {
     "matomo": ">=5.0.0-b1,<6.0.0-b1"

--- a/tests/System/Commands/MigrateTest.php
+++ b/tests/System/Commands/MigrateTest.php
@@ -73,35 +73,11 @@ Migrated 90% of visits at 2019-01-10 02:48:01
 Migrated 2 visits. The number of migrated visits may be higher if data is still tracked into the source Matomo while migrating the data at 2019-01-10 02:48:01
 Processed LogMigration at 2019-01-10 02:48:01
 Processing ArchiveMigration at 2019-01-10 02:48:01
-Found 14 archive tables at 2019-01-10 02:48:01
-Starting to migrate archive table archive_numeric_2013_01 at 2019-01-10 02:48:01
-Migrated archive table archive_numeric_2013_01 at 2019-01-10 02:48:01
-Starting to migrate archive table archive_numeric_2013_02 at 2019-01-10 02:48:01
-Migrated archive table archive_numeric_2013_02 at 2019-01-10 02:48:01
-Starting to migrate archive table archive_numeric_2013_03 at 2019-01-10 02:48:01
-Migrated archive table archive_numeric_2013_03 at 2019-01-10 02:48:01
-Starting to migrate archive table archive_numeric_2013_04 at 2019-01-10 02:48:01
-Migrated archive table archive_numeric_2013_04 at 2019-01-10 02:48:01
-Starting to migrate archive table archive_numeric_2013_05 at 2019-01-10 02:48:01
-Migrated archive table archive_numeric_2013_05 at 2019-01-10 02:48:01
-Starting to migrate archive table archive_numeric_2013_06 at 2019-01-10 02:48:01
-Migrated archive table archive_numeric_2013_06 at 2019-01-10 02:48:01
-Starting to migrate archive table archive_numeric_2013_07 at 2019-01-10 02:48:01
-Migrated archive table archive_numeric_2013_07 at 2019-01-10 02:48:01
-Starting to migrate archive table archive_numeric_2013_08 at 2019-01-10 02:48:01
-Migrated archive table archive_numeric_2013_08 at 2019-01-10 02:48:01
-Starting to migrate archive table archive_numeric_2013_09 at 2019-01-10 02:48:01
-Migrated archive table archive_numeric_2013_09 at 2019-01-10 02:48:01
-Starting to migrate archive table archive_numeric_2013_10 at 2019-01-10 02:48:01
-Migrated archive table archive_numeric_2013_10 at 2019-01-10 02:48:01
-Starting to migrate archive table archive_numeric_2013_11 at 2019-01-10 02:48:01
-Migrated archive table archive_numeric_2013_11 at 2019-01-10 02:48:01
-Starting to migrate archive table archive_numeric_2013_12 at 2019-01-10 02:48:01
-Migrated archive table archive_numeric_2013_12 at 2019-01-10 02:48:01
-Starting to migrate archive table archive_numeric_2014_01 at 2019-01-10 02:48:01
-Migrated archive table archive_numeric_2014_01 at 2019-01-10 02:48:01
+Found 2 archive tables at 2019-01-10 02:48:01
 Starting to migrate archive table archive_blob_2013_01 at 2019-01-10 02:48:01
 Migrated archive table archive_blob_2013_01 at 2019-01-10 02:48:01
+Starting to migrate archive table archive_numeric_2013_01 at 2019-01-10 02:48:01
+Migrated archive table archive_numeric_2013_01 at 2019-01-10 02:48:01
 Processed ArchiveMigration at 2019-01-10 02:48:01
 ', $this->applicationTester->getDisplay());
         $this->assertEquals('0', $result);
@@ -221,9 +197,7 @@ Processed ArchiveMigration at 2019-01-10 02:48:01
     {
         $result = $this->runCommand();
         $this->assertStringContainsString('Starting to migrate archive table archive_numeric_2013_01 at 2019-01-10 02:48:01
-Migrated archive table archive_numeric_2013_01 at 2019-01-10 02:48:01
-Starting to migrate archive table archive_numeric_2013_02 at 2019-01-10 02:48:01
-Migrated archive table archive_numeric_2013_02 at 2019-01-10 02:48:01', $this->applicationTester->getDisplay());
+Migrated archive table archive_numeric_2013_01 at 2019-01-10 02:48:01', $this->applicationTester->getDisplay());
         $this->assertEquals('0', $result);
         $result = $this->runCommand();
         $this->assertEquals('0', $result);

--- a/tests/System/Commands/MigrateTest.php
+++ b/tests/System/Commands/MigrateTest.php
@@ -132,11 +132,7 @@ Processed ArchiveMigration at 2019-01-10 02:48:01
         FakeAccess::clearAccess(true);
         $this->disableArchiving();
 
-        if (in_array($api, [['Live.getLastVisitsDetails'], ['Actions.getPageUrls']]) && version_compare(Version::VERSION, '5.2.0-alpha', '<')) {
-            $params['testSuffix'] = '5-2a';
-        } elseif ($api === ['API.get'] && version_compare(Version::VERSION, '5.2.0-b6', '<')) {
-            $params['testSuffix'] = '5-2b6';
-        }
+        $params['testSuffix'] = $this->getTestSuffix($api);
 
         $this->runApiTests($api, $params);
     }
@@ -153,11 +149,7 @@ Processed ArchiveMigration at 2019-01-10 02:48:01
 
         FakeAccess::clearAccess($superUser = true);
 
-        if (in_array($api, [['Live.getLastVisitsDetails'], ['Actions.getPageUrls']]) && version_compare(Version::VERSION, '5.2.0-alpha', '<')) {
-            $params['testSuffix'] = '5-2a';
-        } elseif ($api === ['API.get'] && version_compare(Version::VERSION, '5.2.0-b6', '<')) {
-            $params['testSuffix'] = '5-2b6';
-        }
+        $params['testSuffix'] = $this->getTestSuffix($api);
         try {
             $this->runApiTests($api, $params);
         } catch (\Exception $e) {
@@ -166,6 +158,22 @@ Processed ArchiveMigration at 2019-01-10 02:48:01
         }
 
         $this->setTargetDbPrefix('');
+    }
+
+    private function getTestSuffix($api)
+    {
+        if (
+            in_array($api, [['Live.getLastVisitsDetails'], ['Actions.getPageUrls'], ['SitesManager.getSiteFromId']])
+            && version_compare(Version::VERSION, '5.2.0-alpha', '<')
+        ) {
+            return '5-2a';
+        }
+
+        if ($api === ['API.get'] && version_compare(Version::VERSION, '5.2.0-b6', '<')) {
+            return '5-2b6';
+        }
+
+        return '';
     }
 
     private function setTargetDbPrefix($prefix)
@@ -196,8 +204,12 @@ Processed ArchiveMigration at 2019-01-10 02:48:01
     public function test_runMigration_CanBeExecutedMultipleTimesWithoutAnyIdProblems()
     {
         $result = $this->runCommand();
-        $this->assertStringContainsString('Starting to migrate archive table archive_numeric_2013_01 at 2019-01-10 02:48:01
-Migrated archive table archive_numeric_2013_01 at 2019-01-10 02:48:01', $this->applicationTester->getDisplay());
+        $output = $this->applicationTester->getDisplay();
+        $this->assertTrue(
+            strpos($output, 'Migrated archive table archive_numeric_2013_01 at 2019-01-10 02:48:01') !== false
+            || strpos($output, 'Skipping table because it is a target table targetdb_archive_numeric_2013_01 and source prefix is: at 2019-01-10 02:48:01') !== false,
+            $output
+        );
         $this->assertEquals('0', $result);
         $result = $this->runCommand();
         $this->assertEquals('0', $result);

--- a/tests/System/Commands/MigrateTest.php
+++ b/tests/System/Commands/MigrateTest.php
@@ -40,7 +40,7 @@ class MigrateTest extends ConsoleCommandTestCase
     public function test_runMigration()
     {
         $result = $this->runCommand();
-        $this->assertEquals('Processing SiteMigration at 2019-01-10 02:48:01
+        $expectedOutput = 'Processing SiteMigration at 2019-01-10 02:48:01
 Target site is 1 at 2019-01-10 02:48:01
 Processed SiteMigration at 2019-01-10 02:48:01
 Processing SiteUrlMigration at 2019-01-10 02:48:01
@@ -72,14 +72,8 @@ Migrated 80% of visits at 2019-01-10 02:48:01
 Migrated 90% of visits at 2019-01-10 02:48:01
 Migrated 2 visits. The number of migrated visits may be higher if data is still tracked into the source Matomo while migrating the data at 2019-01-10 02:48:01
 Processed LogMigration at 2019-01-10 02:48:01
-Processing ArchiveMigration at 2019-01-10 02:48:01
-Found 2 archive tables at 2019-01-10 02:48:01
-Starting to migrate archive table archive_blob_2013_01 at 2019-01-10 02:48:01
-Migrated archive table archive_blob_2013_01 at 2019-01-10 02:48:01
-Starting to migrate archive table archive_numeric_2013_01 at 2019-01-10 02:48:01
-Migrated archive table archive_numeric_2013_01 at 2019-01-10 02:48:01
-Processed ArchiveMigration at 2019-01-10 02:48:01
-', $this->applicationTester->getDisplay());
+' . $this->getExpectedArchiveMigrationOutput();
+        $this->assertEquals($expectedOutput, $this->applicationTester->getDisplay());
         $this->assertEquals('0', $result);
     }
 
@@ -163,7 +157,7 @@ Processed ArchiveMigration at 2019-01-10 02:48:01
     private function getTestSuffix($api)
     {
         if (
-            in_array($api, [['Live.getLastVisitsDetails'], ['Actions.getPageUrls'], ['SitesManager.getSiteFromId']])
+            in_array($api, [['Live.getLastVisitsDetails'], ['Actions.getPageUrls'], ['SitesManager.getSiteFromId'], ['CustomDimensions.getConfiguredCustomDimensions']])
             && version_compare(Version::VERSION, '5.2.0-alpha', '<')
         ) {
             return '5-2a';
@@ -174,6 +168,53 @@ Processed ArchiveMigration at 2019-01-10 02:48:01
         }
 
         return '';
+    }
+
+    private function getExpectedArchiveMigrationOutput()
+    {
+        if (version_compare(Version::VERSION, '5.2.0-alpha', '<')) {
+            return 'Processing ArchiveMigration at 2019-01-10 02:48:01
+Found 14 archive tables at 2019-01-10 02:48:01
+Starting to migrate archive table archive_numeric_2013_01 at 2019-01-10 02:48:01
+Migrated archive table archive_numeric_2013_01 at 2019-01-10 02:48:01
+Starting to migrate archive table archive_numeric_2013_02 at 2019-01-10 02:48:01
+Migrated archive table archive_numeric_2013_02 at 2019-01-10 02:48:01
+Starting to migrate archive table archive_numeric_2013_03 at 2019-01-10 02:48:01
+Migrated archive table archive_numeric_2013_03 at 2019-01-10 02:48:01
+Starting to migrate archive table archive_numeric_2013_04 at 2019-01-10 02:48:01
+Migrated archive table archive_numeric_2013_04 at 2019-01-10 02:48:01
+Starting to migrate archive table archive_numeric_2013_05 at 2019-01-10 02:48:01
+Migrated archive table archive_numeric_2013_05 at 2019-01-10 02:48:01
+Starting to migrate archive table archive_numeric_2013_06 at 2019-01-10 02:48:01
+Migrated archive table archive_numeric_2013_06 at 2019-01-10 02:48:01
+Starting to migrate archive table archive_numeric_2013_07 at 2019-01-10 02:48:01
+Migrated archive table archive_numeric_2013_07 at 2019-01-10 02:48:01
+Starting to migrate archive table archive_numeric_2013_08 at 2019-01-10 02:48:01
+Migrated archive table archive_numeric_2013_08 at 2019-01-10 02:48:01
+Starting to migrate archive table archive_numeric_2013_09 at 2019-01-10 02:48:01
+Migrated archive table archive_numeric_2013_09 at 2019-01-10 02:48:01
+Starting to migrate archive table archive_numeric_2013_10 at 2019-01-10 02:48:01
+Migrated archive table archive_numeric_2013_10 at 2019-01-10 02:48:01
+Starting to migrate archive table archive_numeric_2013_11 at 2019-01-10 02:48:01
+Migrated archive table archive_numeric_2013_11 at 2019-01-10 02:48:01
+Starting to migrate archive table archive_numeric_2013_12 at 2019-01-10 02:48:01
+Migrated archive table archive_numeric_2013_12 at 2019-01-10 02:48:01
+Starting to migrate archive table archive_numeric_2014_01 at 2019-01-10 02:48:01
+Migrated archive table archive_numeric_2014_01 at 2019-01-10 02:48:01
+Starting to migrate archive table archive_blob_2013_01 at 2019-01-10 02:48:01
+Migrated archive table archive_blob_2013_01 at 2019-01-10 02:48:01
+Processed ArchiveMigration at 2019-01-10 02:48:01
+';
+        }
+
+        return 'Processing ArchiveMigration at 2019-01-10 02:48:01
+Found 2 archive tables at 2019-01-10 02:48:01
+Starting to migrate archive table archive_blob_2013_01 at 2019-01-10 02:48:01
+Migrated archive table archive_blob_2013_01 at 2019-01-10 02:48:01
+Starting to migrate archive table archive_numeric_2013_01 at 2019-01-10 02:48:01
+Migrated archive table archive_numeric_2013_01 at 2019-01-10 02:48:01
+Processed ArchiveMigration at 2019-01-10 02:48:01
+';
     }
 
     private function setTargetDbPrefix($prefix)

--- a/tests/System/expected/test_5-2a__CustomDimensions.getConfiguredCustomDimensions.xml
+++ b/tests/System/expected/test_5-2a__CustomDimensions.getConfiguredCustomDimensions.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<idcustomdimension>1</idcustomdimension>
+		<idsite>1</idsite>
+		<name>MyName1</name>
+		<index>1</index>
+		<scope>visit</scope>
+		<active>1</active>
+		<extractions>
+		</extractions>
+		<case_sensitive>1</case_sensitive>
+	</row>
+	<row>
+		<idcustomdimension>2</idcustomdimension>
+		<idsite>1</idsite>
+		<name>MyName2</name>
+		<index>1</index>
+		<scope>action</scope>
+		<active>1</active>
+		<extractions>
+		</extractions>
+		<case_sensitive>1</case_sensitive>
+	</row>
+	<row>
+		<idcustomdimension>3</idcustomdimension>
+		<idsite>1</idsite>
+		<name>MyName3</name>
+		<index>2</index>
+		<scope>action</scope>
+		<active>0</active>
+		<extractions>
+		</extractions>
+		<case_sensitive>1</case_sensitive>
+	</row>
+</result>

--- a/tests/System/expected/test_5-2a__SitesManager.getSiteFromId.xml
+++ b/tests/System/expected/test_5-2a__SitesManager.getSiteFromId.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<idsite>1</idsite>
+		<name>MigrationSite</name>
+		<main_url>http://piwik.net</main_url>
+		<ts_created>2013-01-22 00:00:00</ts_created>
+		<ecommerce>1</ecommerce>
+		<sitesearch>1</sitesearch>
+		<sitesearch_keyword_parameters />
+		<sitesearch_category_parameters />
+		<timezone>UTC</timezone>
+		<currency>USD</currency>
+		<exclude_unknown_urls>0</exclude_unknown_urls>
+		<excluded_ips />
+		<excluded_parameters />
+		<excluded_user_agents />
+		<excluded_referrers />
+		<group />
+		<type>website</type>
+		<keep_url_fragment>0</keep_url_fragment>
+		<creator_login>superUserLogin</creator_login>
+		<timezone_name>UTC</timezone_name>
+		<currency_name>US Dollar</currency_name>
+	</row>
+</result>

--- a/tests/System/expected/test___CustomDimensions.getConfiguredCustomDimensions.xml
+++ b/tests/System/expected/test___CustomDimensions.getConfiguredCustomDimensions.xml
@@ -4,6 +4,7 @@
 		<idcustomdimension>1</idcustomdimension>
 		<idsite>1</idsite>
 		<name>MyName1</name>
+		<description/>
 		<index>1</index>
 		<scope>visit</scope>
 		<active>1</active>
@@ -15,6 +16,7 @@
 		<idcustomdimension>2</idcustomdimension>
 		<idsite>1</idsite>
 		<name>MyName2</name>
+		<description/>
 		<index>1</index>
 		<scope>action</scope>
 		<active>1</active>
@@ -26,6 +28,7 @@
 		<idcustomdimension>3</idcustomdimension>
 		<idsite>1</idsite>
 		<name>MyName3</name>
+		<description/>
 		<index>2</index>
 		<scope>action</scope>
 		<active>0</active>

--- a/tests/System/expected/test___SitesManager.getSiteFromId.xml
+++ b/tests/System/expected/test___SitesManager.getSiteFromId.xml
@@ -3,6 +3,7 @@
 	<row>
 		<idsite>1</idsite>
 		<name>MigrationSite</name>
+		<description/>
 		<main_url>http://piwik.net</main_url>
 		<ts_created>2013-01-22 00:00:00</ts_created>
 		<ecommerce>1</ecommerce>


### PR DESCRIPTION
## Description
Adds code to ignore migration if no option is provided explicitly, like `Y` or `y`

## Issue No
#PG-5167

## Steps to Replicate the Issue
1. Run the console command and press enter
`./console migration:measurable     --source-idsite=1     --target-db-host=127.0.0.1     --target-db-username=root     --target-db-password
=root_1234     --target-db-name=matomo_local     --target-db-prefix=matomo_`
2. This will still work
3. Checkout this PR and try performing the same request, it will abort the request



## Checklist
- [✔] Tested locally or on demo2/demo3?
- [NA] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✔] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?
