### PR TITLE
Fix failing tests on 5.x-dev [no_release]

### DIFF
--- a/tests/System/Commands/MigrateTest.php
+++ b/tests/System/Commands/MigrateTest.php
@@ -167,6 +167,12 @@ Processed LogMigration at 2019-01-10 02:48:01
             return '5-2b6';
         }
 
+        // The folder-level pageUrl segment only included URL aliases as of 5.12.0-alpha
+        // (matomo-org/matomo#24598). Older core still produces a single-clause segment.
+        if ($api === ['Actions.getPageUrls'] && version_compare(Version::VERSION, '5.12.0-alpha', '<')) {
+            return '5-12a';
+        }
+
         return '';
     }
 

--- a/tests/System/expected/test_5-12a__Actions.getPageUrls_day.xml
+++ b/tests/System/expected/test_5-12a__Actions.getPageUrls_day.xml
@@ -45,7 +45,7 @@
 		<avg_time_on_page>180</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>50%</exit_rate>
-		<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fsub,pageUrl=^https%253A%252F%252Fwww.example1.com%252Fsub,pageUrl=^https%253A%252F%252Fwww.example2.net%252Fsub</segment>
+		<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fsub</segment>
 		<subtable>
 			<row>
 				<label>/page</label>

--- a/tests/System/expected/test_5-12a__Actions.getPageUrls_year.xml
+++ b/tests/System/expected/test_5-12a__Actions.getPageUrls_year.xml
@@ -45,24 +45,21 @@
 		<avg_time_on_page>180</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>50%</exit_rate>
-		<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fsub,pageUrl=^https%253A%252F%252Fwww.example1.com%252Fsub,pageUrl=^https%253A%252F%252Fwww.example2.net%252Fsub</segment>
+		<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fsub</segment>
 		<subtable>
 			<row>
 				<label>/page</label>
 				<nb_visits>2</nb_visits>
-				<nb_uniq_visitors>2</nb_uniq_visitors>
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>360</sum_time_spent>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
 				<max_bandwidth />
-				<entry_nb_uniq_visitors>1</entry_nb_uniq_visitors>
 				<entry_nb_visits>1</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>721</entry_sum_visit_length>
 				<entry_bounce_count>0</entry_bounce_count>
-				<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
 				<exit_nb_visits>1</exit_nb_visits>
 				<goals>
 					<row idgoal='ecommerceAbandonedCart'>
@@ -90,6 +87,9 @@
 						<revenue_attrib>2.5</revenue_attrib>
 					</row>
 				</goals>
+				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
+				<sum_daily_entry_nb_uniq_visitors>1</sum_daily_entry_nb_uniq_visitors>
+				<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
 				<avg_time_on_page>180</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>50%</exit_rate>
@@ -101,14 +101,12 @@
 	<row>
 		<label>/index</label>
 		<nb_visits>1</nb_visits>
-		<nb_uniq_visitors>1</nb_uniq_visitors>
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>360</sum_time_spent>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />
 		<max_bandwidth />
-		<entry_nb_uniq_visitors>1</entry_nb_uniq_visitors>
 		<entry_nb_visits>1</entry_nb_visits>
 		<entry_nb_actions>2</entry_nb_actions>
 		<entry_sum_visit_length>544</entry_sum_visit_length>
@@ -141,6 +139,8 @@
 				<nb_conversions_entry>1</nb_conversions_entry>
 			</row>
 		</goals>
+		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
+		<sum_daily_entry_nb_uniq_visitors>1</sum_daily_entry_nb_uniq_visitors>
 		<avg_bandwidth>0</avg_bandwidth>
 		<avg_page_load_time>0</avg_page_load_time>
 		<avg_time_on_page>360</avg_time_on_page>

--- a/tests/System/expected/test___Actions.getPageUrls_year.xml
+++ b/tests/System/expected/test___Actions.getPageUrls_year.xml
@@ -45,7 +45,7 @@
 		<avg_time_on_page>180</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>50%</exit_rate>
-		<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fsub</segment>
+		<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fsub,pageUrl=^https%253A%252F%252Fwww.example1.com%252Fsub,pageUrl=^https%253A%252F%252Fwww.example2.net%252Fsub</segment>
 		<subtable>
 			<row>
 				<label>/page</label>


### PR DESCRIPTION
## Description
Automated fix for failing tests on `5.x-dev`.

- Failing workflow: Plugin Migration Tests
- Failing job(s): PluginTests (matomo5_min_php, maximum_supported_matomo), PluginTests (matomo5_max_php, maximum_supported_matomo)
- CI run: https://github.com/matomo-org/plugin-Migration/actions/runs/27455175002

Generated by automated-test-fixes.

## Issue No
<!-- Mention the issue number this PR addresses. Use GitHub keywords like:
     - Fixes #123 (closes the issue when merged)
     - Resolves #123
     - Related to #123 (if it doesn’t close the issue)
     - JIRA ticket number, if no GitHub issue available
-->

## Steps to Replicate the Issue
1. <!-- Step 1: Describe the action taken. -->
2. <!-- Step 2: What was the expected result? -->
3. <!-- Step 3: What was the actual result? -->



## Checklist
- [✖] Tested locally or on demo2/demo3?
- [✔] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?