### PR TITLE
CLOPS-776 Proposed performance optimisation for migration of log_visit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### 5.0.8 - 2026-06-29
+- Improved visit log migration batching to use idvisit keyset pagination
+
 ### 5.0.7 - 2026-06-08
 - Added code to ignore migration if no option is provided explicitly
 

--- a/Db/BatchQuery.php
+++ b/Db/BatchQuery.php
@@ -46,4 +46,9 @@ class BatchQuery
     {
         return $sql . ' LIMIT ' . (int)$this->limit . ' OFFSET ' . (int) $offset;
     }
+
+    public function getLimit(): int
+    {
+        return $this->limit;
+    }
 }

--- a/Migrations/LogMigration.php
+++ b/Migrations/LogMigration.php
@@ -37,14 +37,22 @@ class LogMigration extends BaseMigration
 
         $logActionMigration = new LogActionMigration();
 
-        $batchQuery = new BatchQuery();
         $count = 0;
-
         $loggedAt = array(0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 0.9);
 
-        foreach ($batchQuery->generateQuery('SELECT * FROM ' . Common::prefixTable('log_visit') . ' WHERE idsite = ? ORDER BY idvisit ASC', array($request->sourceIdSite)) as $visitRows) {
+        $table = Common::prefixTable('log_visit');
+
+        $batchQuery = new BatchQuery();
+        $limit = $batchQuery->getLimit();
+
+        $sql = 'SELECT * FROM %s WHERE idsite = ? AND idvisit > ? ORDER BY idvisit ASC LIMIT %d';
+        $sql = sprintf($sql, $table, $limit);
+
+        $lastIdVisit = 0;
+        while ($visitRows = Db::fetchAll($sql, [$request->sourceIdSite, $lastIdVisit])) {
             $count += count($visitRows);
             $this->migrateVisits($visitRows, $request, $logActionMigration, $targetDb);
+            $lastIdVisit = end($visitRows)['idvisit'];
 
             foreach ($loggedAt as $logAt) {
                 if ($numVisits && ($count / $numVisits) > $logAt) {

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "Migration",
   "description": "Migrate/copy any measurable (site, app, roll-up) from one Matomo to another Matomo",
-  "version": "5.0.7",
+  "version": "5.0.8",
   "theme": false,
   "require": {
     "matomo": ">=5.0.0-b1,<6.0.0-b1"


### PR DESCRIPTION
## Description
- Replaces offset-based batching for `log_visit` with index-based pagination.

Previous SQL:
```
SELECT * FROM log_visit WHERE idsite = 1 ORDER BY idvisit ASC OFFSET 1000000 LIMIT 10000;
```

New SQL:
```
SELECT * FROM log_visit WHERE idsite = 1 AND idvisit > 1234567 ORDER BY idvisit ASC LIMIT 10000;
```

The original SQL iterates through OFFSET records before collection of LIMIT results, which causes a degradation in SQL performance with each batch.
The modified SQL uses the existing index to move straight to the appropriate index position before collecting LIMIT results for that selected idsite. This avoids the iteration time, providing a faster and consistent query time.

The changes in this PR have previously been applied to production Cloud servers to facilitate large migrations by the Support team.

## Issue No
- Relates to [CLOPS-776](https://innocraft.atlassian.net/browse/CLOPS-776)

## Steps to Replicate the Issue
1. Support team initiates IDSite migration for a site with a lot of log_visit records (i.e. 32M)
2. Observe slow performance (i.e. 48h)

## Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules


[CLOPS-776]: https://innocraft.atlassian.net/browse/CLOPS-776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ